### PR TITLE
feat: add related products carousel

### DIFF
--- a/assets/js/theme/common/carousel/related.js
+++ b/assets/js/theme/common/carousel/related.js
@@ -1,0 +1,134 @@
+import 'slick-carousel';
+
+const SECTION_SELECTOR = '[data-related-products]';
+const CAROUSEL_SELECTOR = '[data-related-products-carousel]';
+const PREV_SELECTOR = '[data-related-prev]';
+const NEXT_SELECTOR = '[data-related-next]';
+const DOTS_SELECTOR = '[data-related-dots]';
+
+const observerSupported = typeof window !== 'undefined' && 'IntersectionObserver' in window;
+
+const updateNavState = ($section, slick) => {
+    const $prev = $section.find(PREV_SELECTOR);
+    const $next = $section.find(NEXT_SELECTOR);
+
+    if (!$prev.length || !$next.length) return;
+
+    const slidesToShow = slick.slickGetOption ? slick.slickGetOption('slidesToShow') : slick.options.slidesToShow;
+    const slideCount = slick.slideCount || 0;
+    const disableAll = slideCount <= slidesToShow;
+
+    const atStart = slick.currentSlide === 0;
+    const lastIndex = Math.max(slideCount - slidesToShow, 0);
+    const atEnd = slick.currentSlide >= lastIndex;
+
+    const setButtonState = ($button, disabled) => {
+        $button.prop('disabled', disabled);
+        $button.attr('aria-disabled', disabled);
+    };
+
+    setButtonState($prev, disableAll || atStart);
+    setButtonState($next, disableAll || atEnd);
+};
+
+const initCarousel = ($section) => {
+    const $carousel = $section.find(CAROUSEL_SELECTOR);
+
+    if (!$carousel.length || $carousel.hasClass('slick-initialized')) {
+        return;
+    }
+
+    const $prev = $section.find(PREV_SELECTOR);
+    const $next = $section.find(NEXT_SELECTOR);
+    const $dots = $section.find(DOTS_SELECTOR);
+
+    $carousel.on('init reInit afterChange breakpoint', (event, slick) => {
+        updateNavState($section, slick);
+    });
+
+    $carousel.slick({
+        mobileFirst: true,
+        arrows: true,
+        dots: true,
+        infinite: false,
+        slidesToShow: 1,
+        slidesToScroll: 1,
+        swipeToSlide: true,
+        prevArrow: $prev,
+        nextArrow: $next,
+        appendDots: $dots,
+        adaptiveHeight: false,
+        responsive: [
+            {
+                breakpoint: 768,
+                settings: {
+                    slidesToShow: 2,
+                },
+            },
+            {
+                breakpoint: 992,
+                settings: {
+                    slidesToShow: 3,
+                },
+            },
+            {
+                breakpoint: 1200,
+                settings: {
+                    slidesToShow: 4,
+                },
+            },
+            {
+                breakpoint: 1440,
+                settings: {
+                    slidesToShow: 5,
+                },
+            },
+        ],
+    });
+
+    $carousel.on('keydown', (event) => {
+        const { key } = event;
+        if (key === 'ArrowRight') {
+            event.preventDefault();
+            $carousel.slick('slickNext');
+        }
+
+        if (key === 'ArrowLeft') {
+            event.preventDefault();
+            $carousel.slick('slickPrev');
+        }
+    });
+};
+
+const observeSection = ($section) => {
+    if (!$section.length) return;
+
+    if (!observerSupported) {
+        initCarousel($section);
+        return;
+    }
+
+    const observer = new IntersectionObserver((entries, obs) => {
+        entries.forEach((entry) => {
+            if (entry.isIntersecting) {
+                initCarousel($section);
+                obs.unobserve(entry.target);
+            }
+        });
+    }, {
+        rootMargin: '200px 0px',
+        threshold: 0.1,
+    });
+
+    observer.observe($section.get(0));
+};
+
+export default function initRelatedProductsCarousel() {
+    const $sections = $(SECTION_SELECTOR);
+
+    if (!$sections.length) return;
+
+    $sections.each((_, section) => {
+        observeSection($(section));
+    });
+}

--- a/assets/js/theme/product.js
+++ b/assets/js/theme/product.js
@@ -11,6 +11,7 @@ import modalFactory, { modalTypes } from './global/modal';
 import haloBundleProducts from './halothemes/haloBundleProducts';
 import haloStickyAddToCart from './halothemes/haloStickyAddToCart';
 import haloPrevNextProduct from './halothemes/haloPrevNextProduct';
+import initRelatedProductsCarousel from './common/carousel/related';
 
 const { WRITE_REVIEW } = modalTypes;
 
@@ -49,6 +50,7 @@ export default class Product extends PageManager {
             haloBundleProducts(this.context);   
         }
         haloPrevNextProduct(this.context);
+        initRelatedProductsCarousel();
 
         const $reviewForm = classifyForm('.writeReview-form');
 

--- a/assets/scss/components/_related.scss
+++ b/assets/scss/components/_related.scss
@@ -1,0 +1,195 @@
+.relatedProducts {
+    margin-top: spacing('double');
+
+    &-header {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        gap: spacing('single');
+        margin-bottom: spacing('oneandhalf');
+    }
+
+    &-heading {
+        margin: 0;
+        font-size: fontSize('large');
+        font-weight: fontWeight('semiBold');
+        color: color('heading');
+    }
+
+    &-nav {
+        display: flex;
+        gap: spacing('half');
+    }
+
+    &-navButton {
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        width: remCalc(40);
+        height: remCalc(40);
+        border-radius: 50%;
+        border: 1px solid color('greys', '300');
+        background-color: color('white');
+        color: color('greys', '700');
+        box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+        transition: background-color 150ms ease, color 150ms ease, box-shadow 150ms ease;
+
+        .icon {
+            width: remCalc(16);
+            height: remCalc(16);
+        }
+
+        &:hover,
+        &:focus {
+            background-color: color('primary');
+            color: color('white');
+            box-shadow: 0 4px 12px rgba(0, 0, 0, 0.16);
+            outline: none;
+        }
+
+        &[disabled],
+        &[aria-disabled="true"] {
+            cursor: not-allowed;
+            opacity: 0.4;
+            background-color: color('white');
+            color: color('greys', '500');
+            box-shadow: none;
+        }
+    }
+
+    &-carousel {
+        position: relative;
+    }
+
+    &-slide {
+        padding: 0 spacing('half');
+    }
+
+    &-card {
+        height: 100%;
+        background-color: color('white');
+        border-radius: radius('small');
+        box-shadow: 0 8px 24px rgba(0, 0, 0, 0.04);
+        transition: transform 150ms ease, box-shadow 150ms ease;
+
+        &:hover,
+        &:focus-within {
+            transform: translateY(-2px);
+            box-shadow: 0 12px 32px rgba(0, 0, 0, 0.08);
+        }
+    }
+
+    &-cardLink {
+        display: flex;
+        flex-direction: column;
+        height: 100%;
+        text-decoration: none;
+        color: inherit;
+        padding: spacing('single');
+        gap: spacing('single');
+    }
+
+    &-cardImage {
+        width: 100%;
+        padding-top: 100%;
+        position: relative;
+        overflow: hidden;
+        border-radius: radius('small');
+        background-color: color('greys', '050');
+
+        img {
+            position: absolute;
+            inset: 0;
+            margin: auto;
+            max-height: 100%;
+            width: 100%;
+            object-fit: contain;
+        }
+    }
+
+    &-cardContent {
+        display: flex;
+        flex-direction: column;
+        gap: spacing('half');
+        flex-grow: 1;
+    }
+
+    &-cardTitle {
+        font-size: fontSize('base');
+        font-weight: fontWeight('semiBold');
+        margin: 0;
+        color: color('text');
+        line-height: 1.4;
+    }
+
+    &-cardPrice {
+        font-size: fontSize('large');
+        font-weight: fontWeight('semiBold');
+        color: color('primary');
+    }
+
+    &-cardRating {
+        display: flex;
+        align-items: center;
+        gap: spacing('quarter');
+        font-size: fontSize('small');
+        color: color('text');
+    }
+
+    &-cardReviewCount {
+        font-size: fontSize('small');
+        color: color('greys', '600');
+    }
+
+    &-cardUnitPrice {
+        margin: 0;
+        font-size: fontSize('small');
+        color: color('greys', '600');
+    }
+
+    &-dots {
+        margin-top: spacing('single');
+
+        .slick-dots {
+            display: flex;
+            justify-content: center;
+            gap: spacing('half');
+
+            li {
+                margin: 0;
+            }
+
+            button {
+                width: remCalc(10);
+                height: remCalc(10);
+                padding: 0;
+                border-radius: 50%;
+                background-color: color('greys', '300');
+                border: none;
+                text-indent: -9999px;
+                transition: background-color 150ms ease, transform 150ms ease;
+
+                &:hover,
+                &:focus {
+                    background-color: color('primary');
+                    transform: scale(1.1);
+                    outline: none;
+                }
+            }
+
+            .slick-active button {
+                background-color: color('primary');
+            }
+        }
+    }
+
+    .slick-list {
+        margin: 0 -#{spacing('half')};
+    }
+
+    @include breakpoint('small') {
+        &-cardLink {
+            padding: spacing('oneandhalf');
+        }
+    }
+}

--- a/assets/scss/theme.scss
+++ b/assets/scss/theme.scss
@@ -73,6 +73,7 @@
 @import "../../node_modules/@bigcommerce/citadel/dist/components/components"; // 2
 @import "common/index"; // 3
 @import "components/components"; // 6
+@import "components/related";
 
 
 // Layouts

--- a/templates/components/products/related.html
+++ b/templates/components/products/related.html
@@ -1,8 +1,73 @@
-<h4>{{lang 'products.related_products' }}</h4>
-<ul class="product-list" data-list-name="Related Products">
-    {{#each this}}
-    <li class="product-card">
-            {{>components/products/card settings=../settings theme_settings=../theme_settings event="list" position=(add @index 1)}}
-    </li>
-    {{/each}}
-</ul>
+<section class="relatedProducts" data-related-products aria-label="Products related to this item">
+    <div class="relatedProducts-header">
+        <h2 class="relatedProducts-heading">Products related to this item</h2>
+        <div class="relatedProducts-nav">
+            <button class="relatedProducts-navButton relatedProducts-navButton--prev" type="button" data-related-prev aria-label="Previous related products">
+                <svg class="icon" aria-hidden="true"><use xlink:href="#icon-chevron-left" /></svg>
+            </button>
+            <button class="relatedProducts-navButton relatedProducts-navButton--next" type="button" data-related-next aria-label="Next related products">
+                <svg class="icon" aria-hidden="true"><use xlink:href="#icon-chevron-right" /></svg>
+            </button>
+        </div>
+    </div>
+    <div class="relatedProducts-carousel" data-related-products-carousel aria-roledescription="carousel" tabindex="0">
+        {{#each this}}
+        <div class="relatedProducts-slide">
+            <article class="relatedProducts-card" data-product-id="{{id}}">
+                <a class="relatedProducts-cardLink" href="{{url}}" aria-label="{{name}},{{> components/products/product-aria-label}}">
+                    <div class="relatedProducts-cardImage">
+                        {{> components/common/responsive-img
+                            image=image
+                            class="relatedProducts-cardImg"
+                            fallback_size=../theme_settings.productgallery_size
+                            lazyload='lazyload'
+                            default_image=../theme_settings.default_image_product
+                        }}
+                    </div>
+                    <div class="relatedProducts-cardContent">
+                        <h3 class="relatedProducts-cardTitle">{{name}}</h3>
+                        <div class="relatedProducts-cardPrice">
+                            {{#or ../customer (unless ../settings.hide_price_from_guests)}}
+                                {{#if price.with_tax}}
+                                    {{{price.with_tax.formatted}}}
+                                {{else}}
+                                    {{{price.without_tax.formatted}}}
+                                {{/if}}
+                            {{else}}
+                                {{> components/common/login-for-pricing}}
+                            {{/or}}
+                        </div>
+                        {{#if rating}}
+                            <div class="relatedProducts-cardRating" aria-label="{{rating}} out of 5 stars">
+                                {{> components/products/ratings rating=rating}}
+                                {{#if num_reviews}}
+                                    <span class="relatedProducts-cardReviewCount">({{num_reviews}})</span>
+                                {{/if}}
+                            </div>
+                        {{/if}}
+                        {{#each custom_fields}}
+                            {{#if name '==' 'net_volume_ml'}}
+                                <p class="relatedProducts-cardUnitPrice">
+                                    {{#or ../../customer (unless ../../settings.hide_price_from_guests)}}
+                                        {{#if ../../price.with_tax}}
+                                            {{money (divide ../../price.with_tax.value value)}}
+                                        {{else}}
+                                            {{money (divide ../../price.without_tax.value value)}}
+                                        {{/if}}
+                                        {{#each ../../custom_fields}}
+                                            {{#if name '==' 'unit_of_measure'}}
+                                                <span class="relatedProducts-cardUnitMeasure">/ {{value}}</span>
+                                            {{/if}}
+                                        {{/each}}
+                                    {{/or}}
+                                </p>
+                            {{/if}}
+                        {{/each}}
+                    </div>
+                </a>
+            </article>
+        </div>
+        {{/each}}
+    </div>
+    <div class="relatedProducts-dots" data-related-dots></div>
+</section>


### PR DESCRIPTION
## Summary
- replace the related products snippet with an accessible carousel featuring pricing, ratings, and unit pricing
- add lazy-loaded slick carousel initialization with viewport observer and keyboard support
- style the carousel for responsive layouts and import the new styles into the theme bundle

## Testing
- `npm run stylelint` *(fails: registry denied fetching stylelint@latest)*

------
https://chatgpt.com/codex/tasks/task_e_68d57228ee648325af9b9e44007f938d