### PR TITLE
feat: add product review highlights filtering

### DIFF
--- a/assets/js/theme/product/reviews.js
+++ b/assets/js/theme/product/reviews.js
@@ -17,6 +17,7 @@ export default class {
         this.initLinkBind();
         this.injectPaginationLink();
         this.collapseReviews();
+        this.setupReviewHighlights();
     }
 
     /**
@@ -42,6 +43,184 @@ export default class {
 
         // force collapse on page load
         this.$collapsible.trigger(CollapsibleEvents.click);
+    }
+
+    setupReviewHighlights() {
+        this.$reviewHighlightsBar = $('[data-review-highlights]', this.$reviewsContent);
+        this.$reviewHighlightsList = $('[data-review-highlights-list]', this.$reviewsContent);
+        this.$reviewHighlightsStatus = $('[data-review-highlights-live]', this.$reviewsContent);
+        this.$reviewList = $('#productReviews-list', this.$reviewsContent);
+
+        if (!this.$reviewHighlightsBar.length || !this.$reviewHighlightsList.length || !this.$reviewList.length) {
+            return;
+        }
+
+        this.reviewKeywords = [
+            { key: 'comfort', label: 'Comfort' },
+            { key: 'clarity', label: 'Clarity' },
+            { key: 'moisture', label: 'Moisture' },
+            { key: 'irritation', label: 'Irritation' },
+            { key: 'value', label: 'Value' },
+        ];
+
+        this.reviewKeywordLabels = this.reviewKeywords.reduce((accumulator, keyword) => {
+            accumulator[keyword.key] = keyword.label;
+            return accumulator;
+        }, {});
+
+        const $reviewItems = this.$reviewList.find('.productReview');
+
+        if (!$reviewItems.length) {
+            this.$reviewHighlightsBar.attr('hidden', true);
+            return;
+        }
+
+        this.activeReviewKeyword = null;
+        this.keywordCounts = this.getReviewKeywordCounts($reviewItems);
+        this.$reviewHighlightsBar.removeAttr('hidden');
+        this.renderReviewHighlights();
+        this.bindReviewHighlightEvents();
+    }
+
+    getReviewKeywordCounts($reviewItems) {
+        const counts = this.reviewKeywords.reduce((accumulator, keyword) => {
+            accumulator[keyword.key] = 0;
+            return accumulator;
+        }, {});
+
+        $reviewItems.slice(0, 50).each((_, review) => {
+            const $review = $(review);
+            const text = `${$review.find('.productReview-title').text()} ${$review.find('.productReview-body').text()}`.toLowerCase();
+
+            this.reviewKeywords.forEach((keyword) => {
+                const matches = text.match(new RegExp(`\\b${keyword.key}\\b`, 'gi'));
+
+                if (matches) {
+                    counts[keyword.key] += matches.length;
+                }
+            });
+        });
+
+        return counts;
+    }
+
+    renderReviewHighlights() {
+        if (!this.$reviewHighlightsList.length) {
+            return;
+        }
+
+        const chips = this.reviewKeywords.map((keyword) => {
+            const count = this.keywordCounts[keyword.key] || 0;
+            const isActive = this.activeReviewKeyword === keyword.key;
+
+            return `
+                <button type="button" class="reviewHighlights-chip${isActive ? ' is-active' : ''}" data-review-keyword="${keyword.key}" data-review-label="${keyword.label}" aria-pressed="${isActive}">
+                    <span class="reviewHighlights-label">${keyword.label}</span>
+                    <span class="reviewHighlights-count">(${count})</span>
+                </button>
+            `;
+        });
+
+        if (this.activeReviewKeyword) {
+            chips.push('
+                <button type="button" class="reviewHighlights-chip reviewHighlights-chip--clear" data-review-clear aria-pressed="false">
+                    Clear filters
+                </button>
+            ');
+        }
+
+        this.$reviewHighlightsList.html(chips.join(''));
+    }
+
+    bindReviewHighlightEvents() {
+        this.$reviewHighlightsBar.on('click', '[data-review-keyword]', (event) => {
+            const $target = $(event.currentTarget);
+            const keyword = $target.data('reviewKeyword');
+
+            if (!keyword) {
+                return;
+            }
+
+            if (this.activeReviewKeyword === keyword) {
+                this.clearReviewFilters();
+            } else {
+                this.applyReviewFilter(keyword);
+            }
+        });
+
+        this.$reviewHighlightsBar.on('click', '[data-review-clear]', () => {
+            this.clearReviewFilters();
+        });
+    }
+
+    applyReviewFilter(keyword) {
+        this.activeReviewKeyword = keyword;
+        this.updateReviewVisibility(keyword);
+        this.renderReviewHighlights();
+        this.announceReviewFilter(keyword);
+
+        const $activeChip = this.$reviewHighlightsBar.find(`[data-review-keyword="${keyword}"]`);
+
+        if ($activeChip.length) {
+            $activeChip.focus();
+        }
+    }
+
+    clearReviewFilters() {
+        if (!this.activeReviewKeyword) {
+            return;
+        }
+
+        this.activeReviewKeyword = null;
+        this.updateReviewVisibility();
+        this.renderReviewHighlights();
+        this.announceReviewFilter();
+
+        const $firstChip = this.$reviewHighlightsBar.find('[data-review-keyword]').first();
+
+        if ($firstChip.length) {
+            $firstChip.focus();
+        }
+    }
+
+    updateReviewVisibility(keyword) {
+        if (!this.$reviewList || !this.$reviewList.length) {
+            return;
+        }
+
+        const $reviewItems = this.$reviewList.find('.productReview');
+
+        if (!keyword) {
+            $reviewItems.removeClass('reviewHighlights-hidden');
+            return;
+        }
+
+        const filterRegex = new RegExp(`\\b${keyword}\\b`, 'i');
+
+        $reviewItems.each((_, review) => {
+            const $review = $(review);
+            const text = `${$review.find('.productReview-title').text()} ${$review.find('.productReview-body').text()}`;
+
+            if (filterRegex.test(text.toLowerCase())) {
+                $review.removeClass('reviewHighlights-hidden');
+            } else {
+                $review.addClass('reviewHighlights-hidden');
+            }
+        });
+    }
+
+    announceReviewFilter(keyword) {
+        if (!this.$reviewHighlightsStatus.length) {
+            return;
+        }
+
+        if (!keyword) {
+            this.$reviewHighlightsStatus.text('Cleared review filters');
+            return;
+        }
+
+        const label = this.reviewKeywordLabels[keyword] || keyword;
+        this.$reviewHighlightsStatus.text(`Filtered reviews by ${label}`);
     }
 
     /**

--- a/assets/scss/components/_reviews.scss
+++ b/assets/scss/components/_reviews.scss
@@ -1,0 +1,78 @@
+.reviewHighlights {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    gap: remCalc(8px);
+    margin-bottom: remCalc(24px);
+}
+
+.reviewHighlights-list {
+    display: flex;
+    flex-wrap: wrap;
+    gap: remCalc(8px);
+}
+
+.reviewHighlights-chip {
+    appearance: none;
+    border: 1px solid transparent;
+    border-radius: remCalc(999px);
+    background-color: $color-greyLightest;
+    color: $color-textHeading;
+    cursor: pointer;
+    display: inline-flex;
+    align-items: center;
+    gap: remCalc(4px);
+    font-size: remCalc(14px);
+    line-height: 1.2;
+    padding: remCalc(6px) remCalc(14px);
+    transition: background-color 0.2s ease, color 0.2s ease, border-color 0.2s ease;
+
+    &:hover,
+    &:focus {
+        background-color: $color-greyLight;
+    }
+
+    &:focus-visible {
+        outline: 2px solid $color-primary;
+        outline-offset: 2px;
+    }
+
+    &.is-active {
+        background-color: $color-primary;
+        color: $color-white;
+    }
+
+    &.is-active .reviewHighlights-count {
+        color: $color-white;
+    }
+
+    &--clear {
+        background-color: transparent;
+        border-color: $color-primary;
+        color: $color-primary;
+
+        &:hover,
+        &:focus {
+            background-color: rgba($color-primary, 0.1);
+        }
+    }
+
+    &:disabled,
+    &[aria-pressed='false'][disabled] {
+        cursor: not-allowed;
+        opacity: 0.6;
+    }
+}
+
+.reviewHighlights-count {
+    color: $color-textSecondary;
+    font-size: remCalc(12px);
+}
+
+.reviewHighlights-status {
+    width: 100%;
+}
+
+.productReviews-list .reviewHighlights-hidden {
+    display: none !important;
+}

--- a/assets/scss/theme.scss
+++ b/assets/scss/theme.scss
@@ -73,6 +73,7 @@
 @import "../../node_modules/@bigcommerce/citadel/dist/components/components"; // 2
 @import "common/index"; // 3
 @import "components/components"; // 6
+@import "components/reviews";
 
 
 // Layouts

--- a/templates/components/products/reviews.html
+++ b/templates/components/products/reviews.html
@@ -25,6 +25,10 @@
             {{/if}}
         </h4>
         <div class="toggle-content" id="productReviews-content" aria-hidden="false">
+            <div class="reviewHighlights" data-review-highlights role="group" aria-label="Review highlights">
+                <div class="reviewHighlights-list" data-review-highlights-list></div>
+                <div class="reviewHighlights-status u-hiddenVisually" aria-live="polite" data-review-highlights-live></div>
+            </div>
             <ul class="productReviews-list" id="productReviews-list">
                 {{#each reviews.list}}
                 <li class="productReview">


### PR DESCRIPTION
## Summary
- add a review highlight chip bar to the product reviews template with an aria-live status region
- implement keyword counting, filtering, and announcements for review highlight chips on product pages
- style review highlight chips and ensure the stylesheet is included in the theme build

## Testing
- npm run stylelint *(fails: registry access returns 403 in container environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d56fd4f1f483258697694ab845dc29