### PR TITLE
Add A+ content region to product page

### DIFF
--- a/assets/scss/components/_a-plus.scss
+++ b/assets/scss/components/_a-plus.scss
@@ -1,0 +1,90 @@
+.aPlusContent {
+    background-color: stencilColor('color-white');
+    padding: spacing('triple') 0;
+
+    @media (min-width: 768px) {
+        padding: spacing('quadruple') 0;
+    }
+
+    .container {
+        max-width: 1200px;
+    }
+
+    &-body {
+        display: grid;
+        gap: spacing('double');
+    }
+
+    h2,
+    h3,
+    h4 {
+        color: stencilColor('color-textBase');
+        font-weight: 700;
+        line-height: 1.3;
+        margin: 0;
+    }
+
+    h2 + *,
+    h3 + *,
+    h4 + * {
+        margin-top: spacing('single');
+    }
+
+    p {
+        color: stencilColor('color-textBase');
+        line-height: 1.7;
+        margin: 0;
+    }
+
+    p + * {
+        margin-top: spacing('single');
+    }
+
+    ul,
+    ol {
+        color: stencilColor('color-textBase');
+        line-height: 1.7;
+        margin: 0;
+        padding-left: spacing('double');
+    }
+
+    li + li {
+        margin-top: spacing('half');
+    }
+
+    img {
+        display: block;
+        height: auto;
+        max-width: 100%;
+        width: 100%;
+    }
+
+    .aPlusContent-grid,
+    .image-grid,
+    .imageGrid {
+        display: grid;
+        gap: spacing('double');
+        grid-template-columns: repeat(2, minmax(0, 1fr));
+
+        @media (max-width: 767px) {
+            grid-template-columns: 1fr;
+        }
+    }
+
+    .aPlusContent-grid img,
+    .image-grid img,
+    .imageGrid img {
+        width: 100%;
+    }
+
+    &-footnote,
+    .aPlusContent-footnote,
+    footer {
+        border-top: 1px solid stencilColor('color-border');
+        color: stencilColor('color-textSecondary');
+        font-size: fontSize('smaller');
+        line-height: 1.6;
+        margin-top: spacing('double');
+        padding-top: spacing('single');
+    }
+}

--- a/assets/scss/components/_components.scss
+++ b/assets/scss/components/_components.scss
@@ -191,3 +191,6 @@
 
 // Categories
 @import "stencil/category/component";
+
+// Custom
+@import "a-plus";

--- a/templates/components/products/a-plus.html
+++ b/templates/components/products/a-plus.html
@@ -1,0 +1,24 @@
+{{#if custom_fields}}
+    {{#each custom_fields}}
+        {{#if name '==' 'a_plus_html'}}
+            {{#if value}}
+                <section class="aPlusContent">
+                    <div class="container">
+                        <div class="aPlusContent-body">
+                            {{{ sanitize value allowed_tags="p,h2,h3,h4,ul,ol,li,img,div,span" allowed_attributes="class,alt,src,title" }}}
+                        </div>
+                        {{#each ../custom_fields}}
+                            {{#if name '==' 'a_plus_footnote'}}
+                                {{#if value}}
+                                    <div class="aPlusContent-footnote">
+                                        {{{ sanitize value allowed_tags="p,ul,ol,li,div,span" allowed_attributes="class" }}}
+                                    </div>
+                                {{/if}}
+                            {{/if}}
+                        {{/each}}
+                    </div>
+                </section>
+            {{/if}}
+        {{/if}}
+    {{/each}}
+{{/if}}

--- a/templates/pages/product.html
+++ b/templates/pages/product.html
@@ -39,6 +39,10 @@ product:
             {{> components/products/videos product.videos}}
         {{/if}}
 
+        {{> components/products/tabs}}
+
+        {{> components/products/a-plus product=product custom_fields=product.custom_fields}}
+
         {{#all settings.show_product_reviews theme_settings.show_product_reviews (if theme_settings.show_product_reviews_tabs '!==' true)}}
             <div class="detailReviews-block">
                 <div class="container">
@@ -46,8 +50,6 @@ product:
                 </div>
             </div>
         {{/all}}
-
-        {{> components/products/tabs}}
 
         <div id="detailProduct-banner" class="detailProduct-banner">
             <div class="container">


### PR DESCRIPTION
## Summary
- render sanitized A+ content below the related products section on the PDP
- add optional footnote support sourced from product custom fields
- style the A+ block with responsive image grids and footnote presentation

## Testing
- npm run stylelint *(fails: npm registry returned 403 while fetching stylelint)*

------
https://chatgpt.com/codex/tasks/task_e_68d56bfd01188325aab6768f137c88a0