### PR TITLE
Add frequently bought together bundle strip

### DIFF
--- a/assets/js/theme/product.js
+++ b/assets/js/theme/product.js
@@ -73,6 +73,7 @@ export default class Product extends PageManager {
         });
 
         this.productReviewHandler();
+        this.initializeFrequentlyBoughtTogether();
     }
 
     ariaDescribeReviewInputs($form) {
@@ -221,5 +222,497 @@ export default class Product extends PageManager {
                 }
             }
         });
+    }
+
+    initializeFrequentlyBoughtTogether() {
+        const container = document.querySelector('[data-fbt-skus]');
+
+        if (!container) {
+            return;
+        }
+
+        const productView = document.querySelector('.productView');
+
+        const loadFbt = () => {
+            if (container.getAttribute('data-fbt-initialized') === 'true') {
+                return;
+            }
+
+            container.setAttribute('data-fbt-initialized', 'true');
+            this.setupFrequentlyBoughtTogether(container);
+        };
+
+        if ('IntersectionObserver' in window && productView) {
+            const observer = new IntersectionObserver((entries, obs) => {
+                entries.forEach((entry) => {
+                    if (entry.isIntersecting) {
+                        obs.disconnect();
+                        loadFbt();
+                    }
+                });
+            }, { rootMargin: '0px 0px 200px 0px' });
+
+            observer.observe(productView);
+        } else {
+            loadFbt();
+        }
+    }
+
+    async setupFrequentlyBoughtTogether(container) {
+        const skuList = container.getAttribute('data-fbt-skus');
+
+        if (!skuList) {
+            container.remove();
+            return;
+        }
+
+        const skus = skuList.split(',')
+            .map((sku) => sku.trim())
+            .filter((sku) => sku)
+            .slice(0, 3);
+
+        if (!skus.length) {
+            container.remove();
+            return;
+        }
+
+        const loadingEl = container.querySelector('[data-fbt-loading]');
+        const listEl = container.querySelector('[data-fbt-list]');
+        const totalEl = container.querySelector('[data-fbt-total]');
+        const buttonEl = container.querySelector('[data-fbt-add]');
+
+        if (!listEl || !totalEl || !buttonEl) {
+            return;
+        }
+
+        if (loadingEl) {
+            loadingEl.hidden = false;
+        }
+
+        listEl.setAttribute('aria-busy', 'true');
+
+        let products = [];
+
+        try {
+            products = await this.fetchFrequentlyBoughtProducts(skus);
+        } catch (error) {
+            console.error('Failed to load frequently bought products', error);
+        }
+
+        if (!products.length) {
+            container.remove();
+            return;
+        }
+
+        const formatCurrency = this.getFbtCurrencyFormatter();
+        container.fbtFormatCurrency = formatCurrency;
+
+        listEl.innerHTML = '';
+
+        products.forEach((product, index) => {
+            const itemEl = this.buildFbtItem(product, index, formatCurrency, container);
+
+            if (itemEl) {
+                listEl.appendChild(itemEl);
+            }
+        });
+
+        if (loadingEl) {
+            loadingEl.remove();
+        }
+
+        listEl.setAttribute('aria-busy', 'false');
+
+        this.bindFbtEvents(container);
+        this.updateFbtTotal(container);
+    }
+
+    buildFbtItem(product, index, formatCurrency, container) {
+        if (!product) {
+            return null;
+        }
+
+        const listItem = document.createElement('li');
+        listItem.className = 'productFbt-item';
+        listItem.setAttribute('data-fbt-item', 'true');
+
+        if (product.productId) {
+            listItem.setAttribute('data-product-id', product.productId);
+        }
+
+        if (product.variantId) {
+            listItem.setAttribute('data-variant-id', product.variantId);
+        }
+
+        const checkboxId = `product-fbt-${index}-${product.sku || product.productId || 'item'}`;
+        const checkbox = document.createElement('input');
+        checkbox.type = 'checkbox';
+        checkbox.id = checkboxId;
+        checkbox.checked = true;
+        checkbox.setAttribute('data-fbt-checkbox', 'true');
+        checkbox.setAttribute('data-sku', product.sku || '');
+        checkbox.setAttribute('data-price', product.price);
+
+        const label = document.createElement('label');
+        label.className = 'productFbt-label';
+        label.setAttribute('for', checkboxId);
+
+        const thumbWrapper = document.createElement('span');
+        thumbWrapper.className = 'productFbt-thumb';
+
+        const placeholder = container.getAttribute('data-fbt-placeholder-image');
+        const imageUrl = product.image || placeholder;
+
+        if (imageUrl) {
+            const image = document.createElement('img');
+            image.src = imageUrl;
+            image.alt = product.name;
+            image.loading = 'lazy';
+            thumbWrapper.appendChild(image);
+        }
+
+        const infoWrapper = document.createElement('span');
+        infoWrapper.className = 'productFbt-info';
+
+        const titleLink = document.createElement('a');
+        titleLink.className = 'productFbt-title';
+        titleLink.href = product.url;
+        titleLink.textContent = product.name;
+
+        const priceEl = document.createElement('span');
+        priceEl.className = 'productFbt-price';
+        priceEl.textContent = formatCurrency(product.price);
+
+        infoWrapper.appendChild(titleLink);
+        infoWrapper.appendChild(priceEl);
+
+        label.appendChild(checkbox);
+        label.appendChild(thumbWrapper);
+        label.appendChild(infoWrapper);
+
+        listItem.appendChild(label);
+
+        return listItem;
+    }
+
+    bindFbtEvents(container) {
+        const listEl = container.querySelector('[data-fbt-list]');
+        const buttonEl = container.querySelector('[data-fbt-add]');
+        const errorEl = container.querySelector('[data-fbt-error]');
+
+        if (listEl) {
+            const checkboxes = listEl.querySelectorAll('[data-fbt-checkbox]');
+
+            checkboxes.forEach((checkbox) => {
+                checkbox.addEventListener('change', () => {
+                    this.updateFbtTotal(container);
+                });
+            });
+        }
+
+        if (buttonEl) {
+            buttonEl.dataset.originalText = buttonEl.textContent;
+
+            buttonEl.addEventListener('click', (event) => {
+                event.preventDefault();
+
+                if (buttonEl.disabled) {
+                    return;
+                }
+
+                this.handleFbtAddToCart(container, buttonEl, errorEl);
+            });
+        }
+    }
+
+    updateFbtTotal(container) {
+        const formatCurrency = container.fbtFormatCurrency || ((value) => value);
+        const totalEl = container.querySelector('[data-fbt-total]');
+        const buttonEl = container.querySelector('[data-fbt-add]');
+        const checkboxes = container.querySelectorAll('[data-fbt-checkbox]');
+
+        if (!totalEl || !buttonEl || !checkboxes.length) {
+            return;
+        }
+
+        let total = 0;
+        let selectedCount = 0;
+
+        checkboxes.forEach((checkbox) => {
+            if (checkbox.checked) {
+                selectedCount += 1;
+                total += parseFloat(checkbox.getAttribute('data-price')) || 0;
+            }
+        });
+
+        totalEl.textContent = formatCurrency(total);
+        buttonEl.disabled = selectedCount === 0;
+    }
+
+    handleFbtAddToCart(container, buttonEl, errorEl) {
+        const checkboxes = container.querySelectorAll('[data-fbt-checkbox]:checked');
+
+        if (!checkboxes.length) {
+            return;
+        }
+
+        if (errorEl) {
+            errorEl.textContent = '';
+            errorEl.hidden = true;
+        }
+
+        const originalText = buttonEl.dataset.originalText || buttonEl.textContent;
+        buttonEl.disabled = true;
+        buttonEl.setAttribute('aria-busy', 'true');
+        buttonEl.textContent = 'Adding…';
+
+        const lineItems = [];
+
+        checkboxes.forEach((checkbox) => {
+            const parent = checkbox.closest('[data-fbt-item]');
+
+            if (!parent) {
+                return;
+            }
+
+            const productId = parseInt(parent.getAttribute('data-product-id'), 10);
+            const variantId = parseInt(parent.getAttribute('data-variant-id'), 10);
+
+            if (!productId) {
+                return;
+            }
+
+            const lineItem = {
+                quantity: 1,
+                productId,
+            };
+
+            if (!Number.isNaN(variantId) && variantId) {
+                lineItem.variantId = variantId;
+            }
+
+            lineItems.push(lineItem);
+        });
+
+        if (!lineItems.length) {
+            buttonEl.disabled = false;
+            buttonEl.removeAttribute('aria-busy');
+            buttonEl.textContent = originalText;
+            return;
+        }
+
+        this.addFbtItemsToCart(lineItems)
+            .then(() => {
+                window.location.href = '/cart.php';
+            })
+            .catch((error) => {
+                console.error('Failed to add FBT items to cart', error);
+
+                if (errorEl) {
+                    errorEl.textContent = 'We couldn\'t add these items to your cart. Please try again.';
+                    errorEl.hidden = false;
+                }
+
+                buttonEl.disabled = false;
+                buttonEl.removeAttribute('aria-busy');
+                buttonEl.textContent = originalText;
+            });
+    }
+
+    addFbtItemsToCart(lineItems) {
+        const headers = {
+            'Content-Type': 'application/json',
+            Accept: 'application/json',
+        };
+
+        if (this.context.token) {
+            headers['X-Auth-Token'] = this.context.token;
+        }
+
+        const options = {
+            method: 'POST',
+            credentials: 'same-origin',
+            headers,
+            body: JSON.stringify({ lineItems }),
+        };
+
+        const cartId = this.context.cartId;
+        const endpoint = cartId ? `/api/storefront/carts/${cartId}/items` : '/api/storefront/carts';
+
+        return fetch(endpoint, options)
+            .then((response) => {
+                if (!response.ok) {
+                    throw new Error('Unable to add items to cart');
+                }
+
+                return response.json();
+            })
+            .then((data) => {
+                if (data && data.id) {
+                    this.context.cartId = data.id;
+                }
+
+                return data;
+            });
+    }
+
+    async fetchFrequentlyBoughtProducts(skus) {
+        const include = encodeURIComponent('images,variants');
+        const skuParam = skus.map((sku) => encodeURIComponent(sku)).join(',');
+        const url = `/api/storefront/catalog/products?include=${include}&sku=${skuParam}`;
+
+        const headers = {
+            Accept: 'application/json',
+        };
+
+        if (this.context.token) {
+            headers['X-Auth-Token'] = this.context.token;
+        }
+
+        const response = await fetch(url, {
+            method: 'GET',
+            credentials: 'same-origin',
+            headers,
+        });
+
+        if (!response.ok) {
+            throw new Error('Unable to retrieve FBT products');
+        }
+
+        const payload = await response.json();
+        const products = Array.isArray(payload) ? payload : payload.data || [];
+        const normalized = [];
+
+        skus.forEach((sku) => {
+            const product = products.find((item) => this.productHasSku(item, sku));
+
+            if (!product) {
+                return;
+            }
+
+            const normalizedProduct = this.normalizeFbtProduct(product, sku);
+
+            if (normalizedProduct) {
+                normalized.push(normalizedProduct);
+            }
+        });
+
+        return normalized;
+    }
+
+    productHasSku(product, sku) {
+        if (!product || !sku) {
+            return false;
+        }
+
+        if (product.sku && product.sku === sku) {
+            return true;
+        }
+
+        if (Array.isArray(product.variants)) {
+            return product.variants.some((variant) => variant && variant.sku === sku);
+        }
+
+        return false;
+    }
+
+    normalizeFbtProduct(product, sku) {
+        if (!product) {
+            return null;
+        }
+
+        const variants = Array.isArray(product.variants) ? product.variants : [];
+        const matchedVariant = variants.find((variant) => variant && variant.sku === sku) || variants[0] || null;
+
+        const productId = product.id || (matchedVariant && matchedVariant.product_id) || null;
+        const variantId = matchedVariant && matchedVariant.id ? matchedVariant.id : null;
+        const price = this.extractFbtPrice(matchedVariant, product);
+        const image = (matchedVariant && (matchedVariant.image_url || (matchedVariant.image && (matchedVariant.image.url_thumbnail || matchedVariant.image.url_standard))))
+            || (product.primary_image && (product.primary_image.url_thumbnail || product.primary_image.url_standard))
+            || (Array.isArray(product.images) && product.images.length && (product.images[0].url_thumbnail || product.images[0].url_standard))
+            || '';
+
+        let url = product.path || (product.custom_url && product.custom_url.url) || product.url || '#';
+
+        if (url && url.charAt(0) !== '/' && !/^https?:/i.test(url) && window.BCData && window.BCData.storefrontUrls && window.BCData.storefrontUrls.root) {
+            url = `${window.BCData.storefrontUrls.root}${url}`;
+        }
+
+        const name = (matchedVariant && (matchedVariant.product_name || matchedVariant.description)) || product.name || sku;
+
+        return {
+            productId,
+            variantId,
+            price,
+            image,
+            name,
+            url,
+            sku,
+        };
+    }
+
+    extractFbtPrice(variant, product) {
+        const getNumericValue = (value) => {
+            if (typeof value === 'number' && !Number.isNaN(value)) {
+                return value;
+            }
+
+            if (value && typeof value.value === 'number') {
+                return value.value;
+            }
+
+            if (value && typeof value.amount === 'number') {
+                return value.amount;
+            }
+
+            if (value && typeof value.price === 'number') {
+                return value.price;
+            }
+
+            return null;
+        };
+
+        const sources = [
+            variant && variant.calculated_price,
+            variant && variant.price && variant.price.with_tax,
+            variant && variant.price && variant.price.without_tax,
+            variant && variant.price,
+            product && product.calculated_price,
+            product && product.price && product.price.with_tax,
+            product && product.price && product.price.without_tax,
+            product && product.price,
+        ];
+
+        for (let i = 0; i < sources.length; i += 1) {
+            const numericValue = getNumericValue(sources[i]);
+
+            if (numericValue !== null) {
+                return numericValue;
+            }
+        }
+
+        return 0;
+    }
+
+    getFbtCurrencyFormatter() {
+        const locale = document.documentElement.lang || 'en-US';
+        const currencyData = (window.BCData && window.BCData.store && window.BCData.store.currency) || {};
+        const currencyCode = currencyData.code || this.context.currencyCode || this.context.storeCurrencyCode || 'USD';
+
+        try {
+            const formatter = new Intl.NumberFormat(locale, {
+                style: 'currency',
+                currency: currencyCode,
+            });
+
+            return (value) => formatter.format(value);
+        } catch (error) {
+            const symbol = currencyData.symbol || currencyData.token || '$';
+            const decimals = typeof currencyData.decimalPlaces === 'number'
+                ? currencyData.decimalPlaces
+                : (typeof currencyData.decimal_places === 'number' ? currencyData.decimal_places : 2);
+
+            return (value) => `${symbol}${Number(value || 0).toFixed(decimals)}`;
+        }
     }
 }

--- a/templates/components/products/fbt.html
+++ b/templates/components/products/fbt.html
@@ -1,0 +1,23 @@
+{{#each product.custom_fields}}
+    {{#if name '==' 'fbt_skus'}}
+        {{#if value}}
+            <section class="productFbt" data-fbt-skus="{{value}}" data-fbt-placeholder-image="{{cdn theme_settings.default_image_product}}">
+                <div class="container">
+                    <h2 class="productFbt-heading">Frequently Bought Together</h2>
+                    <div class="productFbt-content" data-fbt-content>
+                        <p class="productFbt-loading" data-fbt-loading aria-live="polite">Loading frequently bought suggestions…</p>
+                        <ul class="productFbt-list" data-fbt-list role="group" aria-label="Frequently bought together products" aria-busy="true"></ul>
+                        <div class="productFbt-summary">
+                            <div class="productFbt-total">
+                                <span class="productFbt-totalLabel">Total:</span>
+                                <span class="productFbt-totalValue" data-fbt-total aria-live="polite">—</span>
+                            </div>
+                            <button type="button" class="button button--primary" data-fbt-add disabled>Add selected to cart</button>
+                        </div>
+                        <p class="productFbt-error" data-fbt-error role="alert" hidden></p>
+                    </div>
+                </div>
+            </section>
+        {{/if}}
+    {{/if}}
+{{/each}}

--- a/templates/pages/product.html
+++ b/templates/pages/product.html
@@ -33,6 +33,8 @@ product:
     <div itemscope itemtype="http://schema.org/Product">
         {{> components/products/product-view schema=true  }}
 
+        {{> components/products/fbt product=product}}
+
         {{{region name="product_below_content"}}}
 
         {{#if product.videos.list.length}}


### PR DESCRIPTION
## Summary
- render a Frequently Bought Together section on the product page via a new partial
- add markup for the bundle list, totals, and accessibility affordances
- load bundle products lazily in product.js, keep totals in sync, and add the selected items to the cart with the Storefront API

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d5662c7f24832583936775939030fd