### PR TITLE
feat(pdp): add subscribe toggle demo

### DIFF
--- a/templates/components/products/buy-box.html
+++ b/templates/components/products/buy-box.html
@@ -1,0 +1,30 @@
+<div class="buyBox" data-buy-box>
+    {{#if product.price}}
+    <div class="buyBox-pricing" data-subscribe-price-region aria-live="polite">
+        <div data-subscribe-price-base>
+            {{> components/products/price price=product.price schema_org=schema}}
+        </div>
+        <div class="subscribeSave-pricing" data-subscribe-price-subscribed hidden>
+            <span class="subscribeSave-priceOriginal" data-subscribe-original-price></span>
+            <span class="subscribeSave-priceDiscounted" data-subscribe-discounted-price></span>
+        </div>
+    </div>
+    {{/if}}
+
+    <div class="subscribeSave">
+        <label class="subscribeSave-toggle">
+            <input type="checkbox" data-subscribe-toggle>
+            <span>Subscribe &amp; Save</span>
+        </label>
+        <div class="subscribeSave-plan" data-subscribe-plan-wrapper hidden>
+            <label class="subscribeSave-planLabel" for="subscribe-plan">Delivery frequency</label>
+            <select id="subscribe-plan" data-subscribe-plan>
+                <option value="30">Every 30 days</option>
+                <option value="60">Every 60 days</option>
+                <option value="90">Every 90 days</option>
+            </select>
+        </div>
+    </div>
+
+    {{> components/products/add-to-cart}}
+</div>


### PR DESCRIPTION
## Summary
- add a Subscribe & Save toggle and frequency dropdown to the buy box, including an aria-live price region
- update product-details logic to apply a demo discount, swap CTA copy, and emit events when subscription settings change

## Testing
- not run (needs `stencil start` for manual verification)


------
https://chatgpt.com/codex/tasks/task_e_68d562b49f4c83259f94d58bdf64988c