### PR TITLE
Add PDP zip-based ETA estimator

### DIFF
--- a/templates/components/products/buy-box.html
+++ b/templates/components/products/buy-box.html
@@ -1,0 +1,2 @@
+<input type="text" class="zipChecker" data-zip-checker maxlength="5" placeholder="Enter ZIP">
+<div class="deliveryEta" data-eta aria-live="polite"></div>


### PR DESCRIPTION
## Summary
- add a ZIP entry and ETA container to the PDP buy box
- calculate and persist a demo delivery ETA based on the shopper ZIP in product-details.js

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d56015a5b883258b29edd5063c9f9d