### PR TITLE
Scaffold amazonized PDP layout

### DIFF
--- a/assets/scss/components/_buy-box.scss
+++ b/assets/scss/components/_buy-box.scss
@@ -1,0 +1,178 @@
+.productView-layout {
+    margin-top: spacing("double");
+}
+
+.productView-grid {
+    display: grid;
+    gap: spacing("double");
+}
+
+.productView-column {
+    min-width: 0;
+}
+
+.productView-column--buyBox {
+    position: relative;
+}
+
+@media (max-width: 1023px) {
+    .productView-grid {
+        grid-template-columns: 1fr;
+    }
+
+    .productView-column--gallery {
+        order: 1;
+    }
+
+    .productView-column--content {
+        order: 2;
+    }
+
+    .productView-column--buyBox {
+        order: 3;
+    }
+
+    .productView-layout {
+        padding-bottom: 96px;
+    }
+}
+
+@media (min-width: 1024px) {
+    .productView-grid {
+        grid-template-columns: minmax(0, 1.5fr) minmax(0, 1.6fr) minmax(320px, 1fr);
+        align-items: start;
+    }
+
+    .productView-column--buyBox {
+        align-self: stretch;
+    }
+
+    .buyBox {
+        position: sticky;
+        top: spacing("double");
+    }
+
+    .buyBox-mobileBar {
+        display: none;
+    }
+}
+
+.buyBox-card {
+    background: #fff;
+    border: 1px solid rgba(0, 0, 0, 0.08);
+    border-radius: 16px;
+    box-shadow: 0 12px 32px rgba(0, 0, 0, 0.08);
+    padding: spacing("double");
+    display: flex;
+    flex-direction: column;
+    gap: spacing("double");
+}
+
+.buyBox-pricing {
+    display: flex;
+    flex-direction: column;
+    gap: spacing("half");
+}
+
+.buyBox-price :is(.price--main, .price--non-sale) {
+    font-size: $h3-font-size;
+    line-height: $h3-line-height;
+}
+
+.buyBox-unitPrice {
+    font-size: $fontSize-root - 1;
+    color: stencilColor('color-textSecondary');
+    display: flex;
+    gap: spacing("quarter");
+    align-items: baseline;
+}
+
+.buyBox-availability,
+.buyBox-fulfillment,
+.buyBox-releaseDate {
+    font-size: $fontSize-root - 1;
+    color: stencilColor('color-textSecondary');
+}
+
+.buyBox-fulfillment {
+    display: flex;
+    flex-wrap: wrap;
+    gap: spacing("half");
+    align-items: center;
+}
+
+.buyBox-zip {
+    display: inline-flex;
+    align-items: center;
+    gap: spacing("quarter");
+}
+
+.buyBox-zipAction {
+    background: none;
+    border: 0;
+    color: stencilColor('color-textLink');
+    cursor: pointer;
+    font-size: inherit;
+    padding: 0;
+    text-decoration: underline;
+}
+
+.buyBox-form {
+    display: flex;
+    flex-direction: column;
+    gap: spacing("single");
+}
+
+.buyBox-quantityCtas {
+    display: flex;
+    flex-direction: column;
+    gap: spacing("single");
+}
+
+.buyBox-subscribe,
+.buyBox-wishlist,
+.buyBox-share {
+    display: flex;
+    justify-content: center;
+}
+
+.buyBox-subscribe .button,
+.buyBox-mobileBar-button {
+    text-transform: uppercase;
+}
+
+.buyBox-socialProof {
+    background: stencilColor('color-bgLight');
+    border-radius: 12px;
+    padding: spacing("single");
+    text-align: center;
+    font-size: $fontSize-root - 1;
+    color: stencilColor('color-textSecondary');
+}
+
+.buyBox-mobileBar {
+    position: fixed;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    background: #fff;
+    box-shadow: 0 -6px 24px rgba(0, 0, 0, 0.1);
+    padding: spacing("single");
+    z-index: 10;
+}
+
+.buyBox-mobileBar-inner {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: spacing("single");
+}
+
+.buyBox-mobileBar-price {
+    font-weight: $body-bold-font-weight;
+}
+
+.buyBox-mobileBar-button {
+    flex: 0 0 auto;
+    min-width: 160px;
+}

--- a/assets/scss/theme.scss
+++ b/assets/scss/theme.scss
@@ -73,6 +73,7 @@
 @import "../../node_modules/@bigcommerce/citadel/dist/components/components"; // 2
 @import "common/index"; // 3
 @import "components/components"; // 6
+@import "components/buy-box";
 
 
 // Layouts

--- a/templates/components/products/buy-box.html
+++ b/templates/components/products/buy-box.html
@@ -1,0 +1,140 @@
+<section class="buyBox" data-sticky-buy-box>
+    <div class="buyBox-card">
+        <div class="buyBox-pricing">
+            {{#if product.call_for_price}}
+                <p class="buyBox-priceText">{{product.call_for_price}}</p>
+            {{else}}
+                <div class="buyBox-price">
+                    {{#or customer (unless settings.hide_price_from_guests)}}
+                        {{> components/products/price price=product.price schema_org=schema}}
+                    {{else}}
+                        {{> components/common/login-for-pricing}}
+                    {{/or}}
+                </div>
+            {{/if}}
+            <div class="buyBox-unitPrice">
+                <span class="buyBox-unitPriceLabel">Unit price</span>
+                <span class="buyBox-unitPriceValue" data-unit-price></span>
+            </div>
+        </div>
+
+        {{{region name="product_below_price"}}}
+
+        {{#if theme_settings.product-countDown}}
+            {{#if theme_settings.product-countDown-type '==' 'all'}}
+                {{#or theme_settings.countDownText theme_settings.product-countDown}}
+                    <div class="productCountDown buyBox-countDown">
+                        {{#if theme_settings.product-countDown-time}}
+                            <div class="countDowntimer product-count-down" data-count-down="{{theme_settings.product-countDown-time}}"></div>
+                        {{/if}}
+                    </div>
+                {{/or}}
+            {{else}}
+                {{#each product.custom_fields}}
+                    {{#if name '===' '__countDown'}}
+                        <div class="productCountDown buyBox-countDown">
+                            <div class="countDowntimer product-count-down" data-count-down="{{{value}}}"></div>
+                        </div>
+                    {{/if}}
+                {{/each}}
+            {{/if}}
+        {{/if}}
+
+        <div class="buyBox-availability" data-product-availability>
+            {{#if product.availability}}
+                <span class="buyBox-availabilityLabel">Availability:</span>
+                <span class="buyBox-availabilityValue">{{product.availability}}</span>
+            {{/if}}
+        </div>
+
+        <div class="buyBox-fulfillment">
+            <div class="buyBox-zip" data-buy-box-zip>
+                <span class="buyBox-zipLabel">Deliver to</span>
+                <span class="buyBox-zipValue" data-zip></span>
+                <button class="buyBox-zipAction" type="button" data-change-zip>Change</button>
+            </div>
+            <div class="buyBox-eta" data-delivery-eta></div>
+        </div>
+
+        {{#if product.release_date }}
+            <p class="buyBox-releaseDate">{{product.release_date}}</p>
+        {{/if}}
+
+        <form class="buyBox-form form" method="post" action="{{product.cart_url}}" enctype="multipart/form-data" data-cart-item-add>
+            <input type="hidden" name="action" value="add">
+            <input type="hidden" name="product_id" value="{{product.id}}"/>
+            <div class="buyBox-options" data-buy-box-options data-product-option-change style="display:none;">
+                {{inject 'showSwatchNames' theme_settings.show_product_swatch_names}}
+                {{#each product.options}}
+                    {{{dynamicComponent 'components/products/options'}}}
+                {{/each}}
+            </div>
+
+            <div class="form-field form-field--stock buyBox-stock{{#unless product.stock_level}} u-hiddenVisually{{/unless}}">
+                <label class="form-label form-label--alternate">
+                    {{lang 'products.current_stock'}}
+                    <span data-product-stock>{{product.stock_level}}</span>
+                </label>
+            </div>
+
+            {{#if product.out_of_stock}}
+                {{#if product.out_of_stock_message}}
+                    {{> components/common/alert/alert-error product.out_of_stock_message}}
+                {{else}}
+                    {{> components/common/alert/alert-error (lang 'products.sold_out')}}
+                {{/if}}
+            {{/if}}
+
+            <div class="buyBox-quantityCtas" data-buy-box-ctas>
+                {{> components/products/add-to-cart}}
+            </div>
+        </form>
+
+        <div class="buyBox-subscribe" data-subscribe-toggle>
+            <button type="button" class="button button--ghost">Subscribe &amp; Save</button>
+        </div>
+
+        {{#if settings.show_wishlist}}
+            <div class="buyBox-wishlist" data-wishlist-action>
+                {{> components/common/wishlist-dropdown}}
+            </div>
+        {{/if}}
+
+        {{#unless is_ajax}}
+            <div class="buyBox-share">
+                {{> components/common/share url=product.url}}
+            </div>
+        {{/unless}}
+
+        {{#if product_layout '!=' 'quickview'}}
+            {{#if theme_settings.halo_sticky_add_to_cart}}
+                {{> components/halothemes/product/halo-sticky-add-to-cart}}
+            {{/if}}
+        {{/if}}
+
+        <div class="buyBox-socialProof" data-social-proof>
+            <p class="buyBox-socialProofText">Over <span data-social-proof-count>{{#each product.custom_fields}}{{#if name '==' 'sold_past_30d'}}{{value}}{{/if}}{{/each}}</span> customers purchased in the last 30 days.</p>
+        </div>
+    </div>
+</section>
+
+{{#if product_layout '!=' 'quickview'}}
+<div class="buyBox-mobileBar" data-buy-box-mobile-bar>
+    <div class="buyBox-mobileBar-inner">
+        <div class="buyBox-mobileBar-price">
+            {{#if product.call_for_price}}
+                <span class="buyBox-mobileBar-priceText">{{product.call_for_price}}</span>
+            {{else}}
+                {{#or customer (unless settings.hide_price_from_guests)}}
+                    {{> components/products/price price=product.price schema_org=false}}
+                {{else}}
+                    {{> components/common/login-for-pricing}}
+                {{/or}}
+            {{/if}}
+        </div>
+        <button class="button button--primary buyBox-mobileBar-button" type="button" data-mobile-add-to-cart>
+            {{lang 'products.add_to_cart'}}
+        </button>
+    </div>
+</div>
+{{/if}}

--- a/templates/components/products/product-view.html
+++ b/templates/components/products/product-view.html
@@ -1,5 +1,5 @@
 <div class="productView" data-event-type="product" data-entity-id="{{product.id}}" data-name="{{product.title}}" data-product-category="{{#each product.category}}{{#if @last}}{{this}}{{else}}{{this}}, {{/if}}{{/each}}" data-product-brand="{{product.brand.name}}" data-product-price="{{#if product.price.with_tax}}{{product.price.with_tax.value}}{{else}}{{product.price.without_tax.value}}{{/if}}" data-product-variant="single-product-option">
-    <div class="container"> 
+    <div class="productView-alerts container">
         {{#each product.reviews.messages}}
             {{#if error}}
                 {{> components/common/alert/alert-error error}}
@@ -8,8 +8,12 @@
                 {{> components/common/alert/alert-success success}}
             {{/if}}
         {{/each}}
+    </div>
 
-        <section class="productView-images" data-image-gallery>
+    <div class="productView-layout container">
+        <div class="productView-grid" data-product-layout>
+            <div class="productView-column productView-column--gallery">
+                <section class="productView-images" data-image-gallery>
             {{!--
                 Note that these image sizes are coupled to image sizes used in /assets/js/theme/common/product-details.js
                 for variant/rule image replacement
@@ -234,7 +238,9 @@
                 </div>
             </div>
         </section>
+            </div>
 
+            <div class="productView-column productView-column--content">
         <section class="productView-details product-data">
             <div class="productView-product">
                 {{#if product_layout '!=' 'quickview'}}
@@ -385,40 +391,6 @@
                 </div>
 
 
-                {{#if product.call_for_price}}
-                    <p class="productView-price">
-                        <span>{{product.call_for_price}}</span>
-                    </p>
-                {{/if}}
-                <div class="productView-price">
-                    {{#or customer (unless settings.hide_price_from_guests)}}
-                        {{> components/products/price price=product.price schema_org=schema}}
-                    {{else}}
-                        {{> components/common/login-for-pricing}}
-                    {{/or}}
-                </div>
-                {{{region name="product_below_price"}}}
-
-                {{#if theme_settings.product-countDown}}
-                    {{#if theme_settings.product-countDown-type '==' 'all'}}
-                        {{#or theme_settings.countDownText theme_settings.product-countDown}}
-                            <div class="productCountDown">
-                                {{#if theme_settings.product-countDown-time}}
-                                    <div class="countDowntimer product-count-down" data-count-down="{{theme_settings.product-countDown-time}}"></div>
-                                {{/if}}
-                            </div>
-                        {{/or}}
-                    {{else}}
-                        {{#each product.custom_fields}}
-                            {{#if name '===' '__countDown'}}
-                                <div class="productCountDown">
-                                    <div class="countDowntimer product-count-down" data-count-down="{{{value}}}"></div>
-                                </div>
-                            {{/if}}
-                        {{/each}}
-                    {{/if}}
-                {{/if}}
-
                 {{#if theme_settings.productView_desShort}}
                     <div class="productView-shortDesc">
                         <p style="-webkit-box-orient: vertical;">{{{ellipsis product.description 150}}}</p>
@@ -427,51 +399,20 @@
             </div>
         </section>
 
-        <section class="productView-details product-options">
-            <div class="productView-options">
-                {{#if product.release_date }}
-                    <p>{{product.release_date}}</p>
-                {{/if}}
-                <form class="form" method="post" action="{{product.cart_url}}" enctype="multipart/form-data"
-                      data-cart-item-add>
-                    <input type="hidden" name="action" value="add">
-                    <input type="hidden" name="product_id" value="{{product.id}}"/>
-                    <div data-product-option-change style="display:none;">
-                        {{inject 'showSwatchNames' theme_settings.show_product_swatch_names}}
-                        {{#each product.options}}
-                            {{{dynamicComponent 'components/products/options'}}}
-                        {{/each}}
-                    </div>
-                    <div class="form-field form-field--stock{{#unless product.stock_level}} u-hiddenVisually{{/unless}}">
-                        <label class="form-label form-label--alternate">
-                            {{lang 'products.current_stock'}}
-                            <span data-product-stock>{{product.stock_level}}</span>
-                        </label>
-                    </div>
-                    {{#if product.out_of_stock}}
-                        {{#if product.out_of_stock_message}}
-                            {{> components/common/alert/alert-error product.out_of_stock_message}}
-                        {{else}}
-                            {{> components/common/alert/alert-error (lang 'products.sold_out')}}
-                        {{/if}}
-                    {{/if}}
-                    
-                    {{> components/products/add-to-cart}}
-                </form>
-                {{#if settings.show_wishlist}}
-                    {{> components/common/wishlist-dropdown}}
-                {{/if}}
-                
-                {{#if product_layout '!=' 'quickview'}}
-                    {{#if theme_settings.halo_sticky_add_to_cart}}
-                        {{> components/halothemes/product/halo-sticky-add-to-cart}}
-                    {{/if}}
-                {{/if}}
             </div>
-            {{#unless is_ajax}}
-                {{> components/common/share url=product.url}}
-            {{/unless}}
-        </section>
+
+            <aside class="productView-column productView-column--buyBox" data-buy-box>
+                {{> components/products/buy-box
+                    product=product
+                    theme_settings=theme_settings
+                    settings=settings
+                    schema=schema
+                    products=products
+                    is_ajax=is_ajax
+                    urls=urls
+                }}
+            </aside>
+        </div>
 
         {{#if theme_settings.halo_viewing_product}}
             <div class="viewing-product">

--- a/templates/pages/product.html
+++ b/templates/pages/product.html
@@ -22,36 +22,38 @@ product:
 {{inject "productSize" theme_settings.product_size}}
 
 {{#partial "page"}}
-    <div class="container"> 
-        {{> components/common/breadcrumbs breadcrumbs=breadcrumbs}}
+    <div class="productPage productPage--amazonized">
+        <div class="container productPage-header">
+            {{> components/common/breadcrumbs breadcrumbs=breadcrumbs}}
 
-        {{#each product.shipping_messages}}
-            {{> components/common/alert/alert-info message}}
-        {{/each}}
-    </div>
+            {{#each product.shipping_messages}}
+                {{> components/common/alert/alert-info message}}
+            {{/each}}
+        </div>
 
-    <div itemscope itemtype="http://schema.org/Product">
-        {{> components/products/product-view schema=true  }}
+        <div class="productPage-body" itemscope itemtype="http://schema.org/Product">
+            {{> components/products/product-view schema=true  }}
 
-        {{{region name="product_below_content"}}}
+            {{{region name="product_below_content"}}}
 
-        {{#if product.videos.list.length}}
-            {{> components/products/videos product.videos}}
-        {{/if}}
+            {{#if product.videos.list.length}}
+                {{> components/products/videos product.videos}}
+            {{/if}}
 
-        {{#all settings.show_product_reviews theme_settings.show_product_reviews (if theme_settings.show_product_reviews_tabs '!==' true)}}
-            <div class="detailReviews-block">
-                <div class="container">
-                    {{> components/products/reviews reviews=product.reviews product=product urls=urls}}
+            {{#all settings.show_product_reviews theme_settings.show_product_reviews (if theme_settings.show_product_reviews_tabs '!==' true)}}
+                <div class="detailReviews-block">
+                    <div class="container">
+                        {{> components/products/reviews reviews=product.reviews product=product urls=urls}}
+                    </div>
                 </div>
-            </div>
-        {{/all}}
+            {{/all}}
 
-        {{> components/products/tabs}}
+            {{> components/products/tabs}}
 
-        <div id="detailProduct-banner" class="detailProduct-banner">
-            <div class="container">
-                <img class="lazyload" src="{{cdn 'img/loading.svg'}}" data-src="https://cdn11.bigcommerce.com/s-{{settings.store_hash}}/product_images/uploaded_images/{{theme_settings.detailProduct_banner}}" alt="Bottom Banner">
+            <div id="detailProduct-banner" class="detailProduct-banner">
+                <div class="container">
+                    <img class="lazyload" src="{{cdn 'img/loading.svg'}}" data-src="https://cdn11.bigcommerce.com/s-{{settings.store_hash}}/product_images/uploaded_images/{{theme_settings.detailProduct_banner}}" alt="Bottom Banner">
+                </div>
             </div>
         </div>
     </div>


### PR DESCRIPTION
## Summary
- wrap the PDP in an amazonized page shell so supporting content remains scoped to the product body
- restructure the product view markup into a three-column grid and delegate pricing/actions to a new buy-box partial with mobile bottom bar scaffolding
- add buy-box component styles for responsive columns, sticky desktop behavior, and the pinned mobile CTA bar

## Testing
- `npm run stylelint` *(fails: registry returned 403 when attempting to download stylelint)*

------
https://chatgpt.com/codex/tasks/task_e_68d4e34662208325ac9be5ead82b8757